### PR TITLE
paper.js: Added missing paper.Project methods

### DIFF
--- a/types/paper/index.d.ts
+++ b/types/paper/index.d.ts
@@ -3237,6 +3237,16 @@ declare module paper {
          * Deselects all selected items in the project.
          */
         deselectAll(): void;
+        
+        /**
+         * Adds the specified layer at the end of the this project’s layers list.
+         */
+        addLayer(layer: Layer): Layer;
+        
+        /**
+         * Inserts the specified layer at the specified index in this project’s layers list.
+         */
+        insertLayer(index: number, layer: Layer): Layer;
 
         /**
          * Perform a hit-test on the items contained within the project at the location of the specified point.


### PR DESCRIPTION
See paper.js docs: 
http://paperjs.org/reference/project/#addlayer-layer
http://paperjs.org/reference/project/#insertlayer-index-item

Please fill in this template.

- [ x ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ x ] Test the change in your own code. (Compile and run.)
- [ x ] Follow the advice from the [readme](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#make-a-pull-request).
- [ x ] Avoid [common mistakes](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/README.md#common-mistakes).
- [ x ] Run `npm run lint package-name` (or `tsc` if no `tslint.json` is present).

Select one of these and delete the others:

If changing an existing definition:
- [ x ] Provide a URL to documentation or source code which provides context for the suggested changes: http://paperjs.org/reference/project/#addlayer-layer

